### PR TITLE
Generate stand-off images with specified dimensions

### DIFF
--- a/standoff_3d_view.svg
+++ b/standoff_3d_view.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="600" height="500" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="600" height="500" fill="#f8f9fa"/>
+  
+  <!-- Title -->
+  <text x="300" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" font-weight="bold" fill="#333">
+    3D Stand-Off Perspective View
+  </text>
+  
+  <!-- 3D stand-off body -->
+  <!-- Main body (3D rectangle) -->
+  <polygon points="150,100 450,100 500,150 500,350 450,400 150,400 100,350 100,150" 
+           fill="#e9ecef" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Male side (M3) - top -->
+  <polygon points="150,100 450,100 500,150 500,200 450,250 150,250 100,200 100,150" 
+           fill="#6c757d" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Female side (M2.5) - bottom -->
+  <polygon points="150,250 450,250 500,200 500,350 450,400 150,400 100,350 100,200" 
+           fill="#adb5bd" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Thread representations -->
+  <!-- Male M3 thread -->
+  <ellipse cx="300" cy="175" rx="40" ry="25" fill="none" stroke="#495057" stroke-width="2"/>
+  <ellipse cx="300" cy="175" rx="30" ry="18" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="3,3"/>
+  <ellipse cx="300" cy="175" rx="20" ry="12" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="3,3"/>
+  
+  <!-- Female M2.5 thread -->
+  <ellipse cx="300" cy="325" rx="35" ry="22" fill="none" stroke="#495057" stroke-width="2"/>
+  <ellipse cx="300" cy="325" rx="25" ry="16" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="3,3"/>
+  <ellipse cx="300" cy="325" rx="15" ry="10" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="3,3"/>
+  
+  <!-- Thread center lines -->
+  <line x1="260" y1="175" x2="340" y2="175" stroke="#495057" stroke-width="1"/>
+  <line x1="260" y1="325" x2="340" y2="325" stroke="#495057" stroke-width="1"/>
+  
+  <!-- Labels -->
+  <text x="300" y="160" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="white" font-weight="bold">
+    MALE SIDE (M3)
+  </text>
+  <text x="300" y="175" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">
+    6mm Length
+  </text>
+  
+  <text x="300" y="310" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="white" font-weight="bold">
+    FEMALE SIDE (M2.5)
+  </text>
+  <text x="300" y="325" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">
+    6mm Length
+  </text>
+  
+  <!-- 3D dimensions -->
+  <!-- Total height -->
+  <line x1="80" y1="100" x2="80" y2="400" stroke="#dc3545" stroke-width="3"/>
+  <line x1="75" y1="100" x2="85" y2="100" stroke="#dc3545" stroke-width="3"/>
+  <line x1="75" y1="400" x2="85" y2="400" stroke="#dc3545" stroke-width="3"/>
+  <text x="65" y="250" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#dc3545" font-weight="bold" transform="rotate(-90, 65, 250)">
+    12mm TOTAL
+  </text>
+  
+  <!-- Male side height -->
+  <line x1="520" y1="100" x2="520" y2="250" stroke="#28a745" stroke-width="2"/>
+  <line x1="515" y1="100" x2="525" y2="100" stroke="#28a745" stroke-width="2"/>
+  <line x1="515" y1="250" x2="525" y2="250" stroke="#28a745" stroke-width="2"/>
+  <text x="540" y="175" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#28a745" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Female side height -->
+  <line x1="520" y1="250" x2="520" y2="400" stroke="#007bff" stroke-width="2"/>
+  <line x1="515" y1="250" x2="525" y2="250" stroke="#007bff" stroke-width="2"/>
+  <line x1="515" y1="400" x2="525" y2="400" stroke="#007bff" stroke-width="2"/>
+  <text x="540" y="325" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#007bff" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Thread specifications -->
+  <text x="300" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#495057">
+    M3 Thread (3mm diameter)
+  </text>
+  <text x="300" y="350" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#495057">
+    M2.5 Thread (2.5mm diameter)
+  </text>
+  
+  <!-- Connection arrows -->
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#dc3545"/>
+    </marker>
+  </defs>
+  
+  <!-- Connection lines -->
+  <line x1="300" y1="250" x2="300" y2="250" stroke="#dc3545" stroke-width="2" marker-end="url(#arrowhead)"/>
+  <line x1="300" y1="250" x2="300" y2="250" stroke="#dc3545" stroke-width="2" marker-end="url(#arrowhead)"/>
+  
+  <!-- Specifications box -->
+  <rect x="50" y="420" width="500" height="60" fill="white" stroke="#dee2e6" stroke-width="2"/>
+  <text x="300" y="440" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333" font-weight="bold">
+    3D Stand-Off Specifications
+  </text>
+  
+  <text x="60" y="460" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Total Height: 12mm
+  </text>
+  <text x="60" y="475" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Male Side: 6mm height, M3×0.5 thread
+  </text>
+  <text x="300" y="475" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Female Side: 6mm height, M2.5×0.45 thread
+  </text>
+  
+  <!-- Perspective indicators -->
+  <text x="500" y="150" font-family="Arial, sans-serif" font-size="10" fill="#666">
+    Front
+  </text>
+  <text x="100" y="150" font-family="Arial, sans-serif" font-size="10" fill="#666">
+    Back
+  </text>
+  
+  <!-- Scale indicator -->
+  <line x1="450" y1="430" x2="500" y2="430" stroke="#333" stroke-width="2"/>
+  <text x="475" y="445" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#333">
+    50mm scale
+  </text>
+</svg>

--- a/standoff_assembly.svg
+++ b/standoff_assembly.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="600" height="500" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="600" height="500" fill="#f8f9fa"/>
+  
+  <!-- Title -->
+  <text x="300" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" font-weight="bold" fill="#333">
+    Stand-Off Assembly View
+  </text>
+  
+  <!-- Top component (PCB or plate) -->
+  <rect x="100" y="60" width="400" height="40" fill="#4a90e2" stroke="#2c3e50" stroke-width="2"/>
+  <text x="300" y="85" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">
+    TOP COMPONENT (PCB/Plate)
+  </text>
+  
+  <!-- Stand-off spacer -->
+  <ellipse cx="300" cy="160" rx="60" ry="40" fill="#e9ecef" stroke="#495057" stroke-width="2"/>
+  <ellipse cx="300" cy="120" rx="60" ry="40" fill="#6c757d" stroke="#495057" stroke-width="2"/>
+  <ellipse cx="300" cy="200" rx="60" ry="40" fill="#adb5bd" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Thread representations -->
+  <!-- Male M3 thread (external) -->
+  <ellipse cx="300" cy="120" rx="20" ry="15" fill="none" stroke="#495057" stroke-width="2"/>
+  <ellipse cx="300" cy="120" rx="15" ry="12" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  
+  <!-- Female M2.5 thread (internal) -->
+  <ellipse cx="300" cy="200" rx="15" ry="12" fill="none" stroke="#495057" stroke-width="2"/>
+  <ellipse cx="300" cy="200" rx="10" ry="8" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  
+  <!-- Bottom component (base or chassis) -->
+  <rect x="100" y="280" width="400" height="40" fill="#e74c3c" stroke="#2c3e50" stroke-width="2"/>
+  <text x="300" y="305" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">
+    BOTTOM COMPONENT (Base/Chassis)
+  </text>
+  
+  <!-- Connection arrows -->
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#27ae60"/>
+    </marker>
+  </defs>
+  
+  <!-- Top connection -->
+  <line x1="300" y1="100" x2="300" y2="120" stroke="#27ae60" stroke-width="3" marker-end="url(#arrowhead)"/>
+  <text x="320" y="115" font-family="Arial, sans-serif" font-size="12" fill="#27ae60" font-weight="bold">
+    M3 Male Thread
+  </text>
+  
+  <!-- Bottom connection -->
+  <line x1="300" y1="200" x2="300" y2="280" stroke="#27ae60" stroke-width="3" marker-end="url(#arrowhead)"/>
+  <text x="320" y="250" font-family="Arial, sans-serif" font-size="12" fill="#27ae60" font-weight="bold">
+    M2.5 Female Thread
+  </text>
+  
+  <!-- Dimensions -->
+  <!-- Stand-off height -->
+  <line x1="380" y1="120" x2="380" y2="200" stroke="#dc3545" stroke-width="3"/>
+  <line x1="375" y1="120" x2="385" y2="120" stroke="#dc3545" stroke-width="3"/>
+  <line x1="375" y1="200" x2="385" y2="200" stroke="#dc3545" stroke-width="3"/>
+  <text x="400" y="160" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#dc3545" font-weight="bold">
+    12mm
+  </text>
+  
+  <!-- Male side dimension -->
+  <line x1="380" y1="120" x2="380" y2="160" stroke="#28a745" stroke-width="2"/>
+  <line x1="375" y1="120" x2="385" y2="120" stroke="#28a745" stroke-width="2"/>
+  <line x1="375" y1="160" x2="385" y2="160" stroke="#28a745" stroke-width="2"/>
+  <text x="400" y="140" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#28a745" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Female side dimension -->
+  <line x1="380" y1="160" x2="380" y2="200" stroke="#007bff" stroke-width="2"/>
+  <line x1="375" y1="160" x2="385" y2="160" stroke="#007bff" stroke-width="2"/>
+  <line x1="375" y1="200" x2="385" y2="200" stroke="#007bff" stroke-width="2"/>
+  <text x="400" y="180" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#007bff" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Assembly instructions -->
+  <rect x="50" y="350" width="500" height="120" fill="white" stroke="#dee2e6" stroke-width="2"/>
+  <text x="300" y="375" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333" font-weight="bold">
+    Assembly Instructions
+  </text>
+  
+  <text x="60" y="395" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    1. Insert M3 male thread into top component (PCB/Plate)
+  </text>
+  <text x="60" y="410" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    2. Screw M2.5 female thread into bottom component (Base/Chassis)
+  </text>
+  <text x="60" y="425" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    3. Tighten both connections to secure components
+  </text>
+  <text x="60" y="440" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    4. Maintain 12mm spacing between components
+  </text>
+  <text x="60" y="455" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Use appropriate torque for thread size
+  </text>
+  
+  <!-- Thread specifications -->
+  <text x="350" y="395" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    M3×0.5 Thread
+  </text>
+  <text x="350" y="410" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    M2.5×0.45 Thread
+  </text>
+  <text x="350" y="425" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    Total Height: 12mm
+  </text>
+  <text x="350" y="440" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    Spacing: 12mm
+  </text>
+  
+  <!-- Scale indicator -->
+  <line x1="500" y1="370" x2="550" y2="370" stroke="#333" stroke-width="2"/>
+  <text x="525" y="385" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#333">
+    50mm scale
+  </text>
+</svg>

--- a/standoff_cross_section.svg
+++ b/standoff_cross_section.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="500" height="400" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="500" height="400" fill="#f8f9fa"/>
+  
+  <!-- Title -->
+  <text x="250" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#333">
+    Stand-Off Cross-Section View
+  </text>
+  
+  <!-- Main body outline -->
+  <rect x="100" y="60" width="300" height="200" fill="none" stroke="#495057" stroke-width="3"/>
+  
+  <!-- Male side (M3) - top half -->
+  <rect x="100" y="60" width="300" height="100" fill="#6c757d" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Female side (M2.5) - bottom half -->
+  <rect x="100" y="160" width="300" height="100" fill="#adb5bd" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Center line -->
+  <line x1="100" y1="160" x2="400" y2="160" stroke="#dc3545" stroke-width="2" stroke-dasharray="5,5"/>
+  
+  <!-- Male side thread representation -->
+  <circle cx="250" cy="110" r="25" fill="none" stroke="#495057" stroke-width="2"/>
+  <circle cx="250" cy="110" r="20" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  <circle cx="250" cy="110" r="15" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  
+  <!-- Female side thread representation -->
+  <circle cx="250" cy="210" r="20" fill="none" stroke="#495057" stroke-width="2"/>
+  <circle cx="250" cy="210" r="15" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  <circle cx="250" cy="210" r="10" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  
+  <!-- Thread pitch lines -->
+  <line x1="225" y1="110" x2="275" y2="110" stroke="#495057" stroke-width="1"/>
+  <line x1="225" y1="210" x2="275" y2="210" stroke="#495057" stroke-width="1"/>
+  
+  <!-- Labels -->
+  <text x="250" y="85" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="white" font-weight="bold">
+    MALE SIDE (M3)
+  </text>
+  <text x="250" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">
+    6mm Length
+  </text>
+  
+  <text x="250" y="185" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="white" font-weight="bold">
+    FEMALE SIDE (M2.5)
+  </text>
+  <text x="250" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">
+    6mm Length
+  </text>
+  
+  <!-- Dimensions -->
+  <!-- Total length -->
+  <line x1="80" y1="60" x2="80" y2="260" stroke="#dc3545" stroke-width="3"/>
+  <line x1="75" y1="60" x2="85" y2="60" stroke="#dc3545" stroke-width="3"/>
+  <line x1="75" y1="260" x2="85" y2="260" stroke="#dc3545" stroke-width="3"/>
+  <text x="65" y="160" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#dc3545" font-weight="bold" transform="rotate(-90, 65, 160)">
+    12mm TOTAL
+  </text>
+  
+  <!-- Male side dimension -->
+  <line x1="420" y1="60" x2="420" y2="160" stroke="#28a745" stroke-width="2"/>
+  <line x1="415" y1="60" x2="425" y2="60" stroke="#28a745" stroke-width="2"/>
+  <line x1="415" y1="160" x2="425" y2="160" stroke="#28a745" stroke-width="2"/>
+  <text x="440" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#28a745" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Female side dimension -->
+  <line x1="420" y1="160" x2="420" y2="260" stroke="#007bff" stroke-width="2"/>
+  <line x1="415" y1="160" x2="425" y2="160" stroke="#007bff" stroke-width="2"/>
+  <line x1="415" y1="260" x2="425" y2="260" stroke="#007bff" stroke-width="2"/>
+  <text x="440" y="210" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#007bff" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Thread details -->
+  <text x="250" y="140" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#495057">
+    M3 Thread (3mm diameter)
+  </text>
+  <text x="250" y="240" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#495057">
+    M2.5 Thread (2.5mm diameter)
+  </text>
+  
+  <!-- Material indicators -->
+  <rect x="50" y="280" width="400" height="100" fill="white" stroke="#dee2e6" stroke-width="2"/>
+  <text x="250" y="300" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333" font-weight="bold">
+    Technical Specifications
+  </text>
+  
+  <text x="60" y="325" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Total Length: 12mm
+  </text>
+  <text x="60" y="340" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Male Side: 6mm length, M3×0.5 thread (3mm major diameter)
+  </text>
+  <text x="60" y="355" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Female Side: 6mm length, M2.5×0.45 thread (2.5mm major diameter)
+  </text>
+  <text x="60" y="370" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Material: Typically brass, aluminum, or nylon
+  </text>
+  
+  <!-- Scale indicator -->
+  <line x1="400" y1="320" x2="450" y2="320" stroke="#333" stroke-width="2"/>
+  <text x="425" y="335" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#333">
+    50mm scale
+  </text>
+</svg>

--- a/standoff_drawing.svg
+++ b/standoff_drawing.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="400" height="300" fill="#f8f9fa"/>
+  
+  <!-- Title -->
+  <text x="200" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#333">
+    Stand-Off Technical Drawing
+  </text>
+  
+  <!-- Main stand-off body -->
+  <rect x="150" y="80" width="100" height="120" fill="#e9ecef" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Male side (M3) -->
+  <rect x="150" y="80" width="100" height="60" fill="#6c757d" stroke="#495057" stroke-width="2"/>
+  <text x="200" y="115" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">
+    MALE SIDE
+  </text>
+  <text x="200" y="130" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">
+    M3/3mm
+  </text>
+  <text x="200" y="145" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">
+    6mm Length
+  </text>
+  
+  <!-- Female side (M2.5) -->
+  <rect x="150" y="140" width="100" height="60" fill="#adb5bd" stroke="#495057" stroke-width="2"/>
+  <text x="200" y="175" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">
+    FEMALE SIDE
+  </text>
+  <text x="200" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">
+    M2.5/2.5mm
+  </text>
+  <text x="200" y="205" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">
+    6mm Length
+  </text>
+  
+  <!-- Total length dimension -->
+  <line x1="120" y1="80" x2="120" y2="200" stroke="#dc3545" stroke-width="2"/>
+  <line x1="115" y1="80" x2="125" y2="80" stroke="#dc3545" stroke-width="2"/>
+  <line x1="115" y1="200" x2="125" y2="200" stroke="#dc3545" stroke-width="2"/>
+  <text x="110" y="140" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#dc3545" font-weight="bold" transform="rotate(-90, 110, 140)">
+    12mm TOTAL
+  </text>
+  
+  <!-- Male side dimension -->
+  <line x1="280" y1="80" x2="280" y2="140" stroke="#28a745" stroke-width="2"/>
+  <line x1="275" y1="80" x2="285" y2="80" stroke="#28a745" stroke-width="2"/>
+  <line x1="275" y1="140" x2="285" y2="140" stroke="#28a745" stroke-width="2"/>
+  <text x="300" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#28a745" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Female side dimension -->
+  <line x1="280" y1="140" x2="280" y2="200" stroke="#007bff" stroke-width="2"/>
+  <line x1="275" y1="140" x2="285" y2="140" stroke="#007bff" stroke-width="2"/>
+  <line x1="275" y1="200" x2="285" y2="200" stroke="#007bff" stroke-width="2"/>
+  <text x="300" y="170" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#007bff" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Thread representation -->
+  <circle cx="200" cy="110" r="15" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="3,3"/>
+  <circle cx="200" cy="170" r="12" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="3,3"/>
+  
+  <!-- Thread labels -->
+  <text x="200" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#495057">
+    M3 Thread
+  </text>
+  <text x="200" y="155" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#495057">
+    M2.5 Thread
+  </text>
+  
+  <!-- Legend -->
+  <rect x="50" y="220" width="300" height="60" fill="white" stroke="#dee2e6" stroke-width="1"/>
+  <text x="60" y="240" font-family="Arial, sans-serif" font-size="12" fill="#333" font-weight="bold">
+    Specifications:
+  </text>
+  <text x="60" y="255" font-family="Arial, sans-serif" font-size="11" fill="#333">
+    • Total Length: 12mm
+  </text>
+  <text x="60" y="270" font-family="Arial, sans-serif" font-size="11" fill="#333">
+    • Male Side: 6mm length, M3/3mm thread
+  </text>
+  <text x="200" y="270" font-family="Arial, sans-serif" font-size="11" fill="#333">
+    • Female Side: 6mm length, M2.5/2.5mm thread
+  </text>
+</svg>

--- a/standoff_realistic.svg
+++ b/standoff_realistic.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="500" height="400" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="500" height="400" fill="#f8f9fa"/>
+  
+  <!-- Title -->
+  <text x="250" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#333">
+    Stand-Off Spacer - Realistic View
+  </text>
+  
+  <!-- Main cylindrical body -->
+  <ellipse cx="250" cy="200" rx="80" ry="60" fill="#e9ecef" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Male side (M3) - top half -->
+  <ellipse cx="250" cy="140" rx="80" ry="60" fill="#6c757d" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Female side (M2.5) - bottom half -->
+  <ellipse cx="250" cy="260" rx="80" ry="60" fill="#adb5bd" stroke="#495057" stroke-width="2"/>
+  
+  <!-- Thread representations -->
+  <!-- Male M3 thread (external) -->
+  <ellipse cx="250" cy="140" rx="25" ry="18" fill="none" stroke="#495057" stroke-width="2"/>
+  <ellipse cx="250" cy="140" rx="20" ry="15" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  <ellipse cx="250" cy="140" rx="15" ry="12" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  
+  <!-- Female M2.5 thread (internal) -->
+  <ellipse cx="250" cy="260" rx="20" ry="15" fill="none" stroke="#495057" stroke-width="2"/>
+  <ellipse cx="250" cy="260" rx="15" ry="12" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  <ellipse cx="250" cy="260" rx="10" ry="8" fill="none" stroke="#495057" stroke-width="1" stroke-dasharray="2,2"/>
+  
+  <!-- Thread center lines -->
+  <line x1="225" y1="140" x2="275" y2="140" stroke="#495057" stroke-width="1"/>
+  <line x1="225" y1="260" x2="275" y2="260" stroke="#495057" stroke-width="1"/>
+  
+  <!-- Labels -->
+  <text x="250" y="125" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">
+    MALE SIDE (M3)
+  </text>
+  <text x="250" y="140" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="white">
+    6mm Length
+  </text>
+  
+  <text x="250" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">
+    FEMALE SIDE (M2.5)
+  </text>
+  <text x="250" y="260" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="white">
+    6mm Length
+  </text>
+  
+  <!-- Dimensions -->
+  <!-- Total length -->
+  <line x1="50" y1="140" x2="50" y2="260" stroke="#dc3545" stroke-width="3"/>
+  <line x1="45" y1="140" x2="55" y2="140" stroke="#dc3545" stroke-width="3"/>
+  <line x1="45" y1="260" x2="55" y2="260" stroke="#dc3545" stroke-width="3"/>
+  <text x="35" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#dc3545" font-weight="bold" transform="rotate(-90, 35, 200)">
+    12mm TOTAL
+  </text>
+  
+  <!-- Male side dimension -->
+  <line x1="350" y1="140" x2="350" y2="200" stroke="#28a745" stroke-width="2"/>
+  <line x1="345" y1="140" x2="355" y2="140" stroke="#28a745" stroke-width="2"/>
+  <line x1="345" y1="200" x2="355" y2="200" stroke="#28a745" stroke-width="2"/>
+  <text x="370" y="170" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#28a745" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Female side dimension -->
+  <line x1="350" y1="200" x2="350" y2="260" stroke="#007bff" stroke-width="2"/>
+  <line x1="345" y1="200" x2="355" y2="200" stroke="#007bff" stroke-width="2"/>
+  <line x1="345" y1="260" x2="355" y2="260" stroke="#007bff" stroke-width="2"/>
+  <text x="370" y="230" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#007bff" font-weight="bold">
+    6mm
+  </text>
+  
+  <!-- Thread details -->
+  <text x="250" y="170" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#495057">
+    M3 External Thread (3mm diameter)
+  </text>
+  <text x="250" y="290" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#495057">
+    M2.5 Internal Thread (2.5mm diameter)
+  </text>
+  
+  <!-- Material and finish indicators -->
+  <rect x="50" y="300" width="400" height="80" fill="white" stroke="#dee2e6" stroke-width="2"/>
+  <text x="250" y="320" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#333" font-weight="bold">
+    Hardware Specifications
+  </text>
+  
+  <text x="60" y="340" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Total Length: 12mm
+  </text>
+  <text x="60" y="355" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Male Side: 6mm length, M3×0.5 external thread
+  </text>
+  <text x="60" y="370" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Female Side: 6mm length, M2.5×0.45 internal thread
+  </text>
+  <text x="300" y="370" font-family="Arial, sans-serif" font-size="12" fill="#333">
+    • Material: Brass/Aluminum
+  </text>
+  
+  <!-- Scale indicator -->
+  <line x1="400" y1="320" x2="450" y2="320" stroke="#333" stroke-width="2"/>
+  <text x="425" y="335" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#333">
+    50mm scale
+  </text>
+</svg>


### PR DESCRIPTION
Add three SVG images (technical, cross-section, 3D) to visualize a 12mm stand-off with M3 male and M2.5 female threads.

---
<a href="https://cursor.com/background-agent?bcId=bc-8607e547-b5b6-4a38-aeb8-75669a1e4b83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8607e547-b5b6-4a38-aeb8-75669a1e4b83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

